### PR TITLE
CC-29787 Fixed mapper checks if no Unzer credentials set.

### DIFF
--- a/src/SprykerEco/Glue/UnzerRestApi/Plugin/CheckoutRestApi/UnzerCheckoutDataResponseMapperPlugin.php
+++ b/src/SprykerEco/Glue/UnzerRestApi/Plugin/CheckoutRestApi/UnzerCheckoutDataResponseMapperPlugin.php
@@ -22,6 +22,7 @@ class UnzerCheckoutDataResponseMapperPlugin extends AbstractPlugin implements Ch
      * {@inheritDoc}
      * - Requires `RestCheckoutDataTransfer.quote.unzerCredentials.unzerKeypair.publicKey` to be set while `RestCheckoutDataTransfer.quote.unzerCredentials` is specified.
      * - Maps `RestCheckoutDataTransfer.unzerCredentials.unzerKeypair.publicKey` to `RestCheckoutDataResponseAttributesTransfer.unzerPublicKey` while `RestCheckoutDataTransfer.unzerCredentials` is specified.
+     * - Does nothing if `RestCheckoutDataTransfer.quote.unzerCredentials.unzerKeypair` is not set.
      *
      * @api
      *

--- a/src/SprykerEco/Glue/UnzerRestApi/Processor/Mapper/RestCheckoutDataResponseAttributesMapper.php
+++ b/src/SprykerEco/Glue/UnzerRestApi/Processor/Mapper/RestCheckoutDataResponseAttributesMapper.php
@@ -22,14 +22,15 @@ class RestCheckoutDataResponseAttributesMapper implements RestCheckoutDataRespon
         RestCheckoutDataTransfer $restCheckoutDataTransfer,
         RestCheckoutDataResponseAttributesTransfer $restCheckoutDataResponseAttributesTransfer
     ): RestCheckoutDataResponseAttributesTransfer {
-        if ($restCheckoutDataTransfer->getQuoteOrFail()->getUnzerCredentials() === null) {
+        $unzerCredentialsTransfer = $restCheckoutDataTransfer->getQuoteOrFail()->getUnzerCredentials();
+        if ($unzerCredentialsTransfer === null || $unzerCredentialsTransfer->getUnzerKeypair() === null) {
             return $restCheckoutDataResponseAttributesTransfer;
         }
 
         $unzerPublicKey = $restCheckoutDataTransfer->getQuoteOrFail()
             ->getUnzerCredentialsOrFail()
             ->getUnzerKeypairOrFail()
-            ->getPublicKeyOrFail();
+            ->getPublicKey();
 
         return $restCheckoutDataResponseAttributesTransfer->setUnzerPublicKey($unzerPublicKey);
     }


### PR DESCRIPTION
- Developer(s): @kkicheglovspryker 

- Ticket: https://spryker.atlassian.net/browse/CC-29787

- Release Group: https://release.spryker.com/release-groups/view/4874

- PR Overview: https://release.spryker.com/release/pull-request-eco/UnzerRestApi/10

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   UnzerRestApi             | patch (currently 0.x)                 |                     |

-----------------------------------------

#### Module UnzerRestApi

##### Change log

Fixes
- Fixed `UnzerCheckoutDataResponseMapperPlugin::mapRestCheckoutDataResponseTransferToRestCheckoutDataResponseAttributesTransfer()` so it will do nothing if `RestCheckoutDataTransfer.quote.unzerCredentials.unzerKeypair` is not set.
